### PR TITLE
Add SPDX builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 .vscode/
 .DS_Store
 *.swp
+scratch/

--- a/main.py
+++ b/main.py
@@ -21,8 +21,8 @@ def makeCmakeSpdx(replyIndexPath, srcRootDir, spdxOutputDir, spdxNamespacePrefix
     srcCfg.doSHA256 = True
     srcCfg.scandir = srcRootDir
     srcCfg.excludeDirs.append(cm.paths_build)
-    pkg = makeSPDX(srcCfg, srcSpdxPath)
-    if pkg:
+    srcPkg = makeSPDX(srcCfg, srcSpdxPath)
+    if srcPkg:
         print(f"Saved sources SPDX to {srcSpdxPath}")
     else:
         print(f"Couldn't generate sources SPDX file")
@@ -36,12 +36,16 @@ def makeCmakeSpdx(replyIndexPath, srcRootDir, spdxOutputDir, spdxNamespacePrefix
     buildCfg.spdxID = "SPDXRef-build"
     buildCfg.doSHA256 = True
     buildCfg.scandir = cm.paths_build
-    pkg = makeSPDX(buildCfg, buildSpdxPath)
-    if pkg:
+    # exclude CMake file-based API responses -- presume only used for this
+    # SPDX generation scan, not for actual build artifact
+    buildExcludeDir = os.path.join(cm.paths_build, ".cmake", "api")
+    print(f"buildExcludeDir = {buildExcludeDir}")
+    buildCfg.excludeDirs.append(buildExcludeDir)
+    buildPkg = makeSPDX(buildCfg, buildSpdxPath)
+    if buildPkg:
         print(f"Saved build SPDX to {buildSpdxPath}")
     else:
         print(f"Couldn't generate build SPDX file")
-
 
 if __name__ == "__main__":
     if len(sys.argv) < 5:

--- a/main.py
+++ b/main.py
@@ -1,13 +1,55 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import sys
 
 from cmakefileapijson import parseReply
+from spdx.builder import BuilderConfig, makeSPDX
+
+def makeCmakeSpdx(replyIndexPath, srcRootDir, spdxOutputDir, spdxNamespacePrefix):
+    # get CMake info from build
+    replyIndexPath = sys.argv[1]
+    cm = parseReply(replyIndexPath)
+
+    # create SPDX file for sources
+    srcSpdxPath = os.path.join(spdxOutputDir, "sources.spdx")
+    srcCfg = BuilderConfig()
+    srcCfg.documentName = "sources"
+    srcCfg.documentNamespace = os.path.join(spdxNamespacePrefix, "sources")
+    srcCfg.packageName = "sources"
+    srcCfg.spdxID = "SPDXRef-sources"
+    srcCfg.doSHA256 = True
+    srcCfg.scandir = srcRootDir
+    srcCfg.excludeDirs.append(cm.paths_build)
+    pkg = makeSPDX(srcCfg, srcSpdxPath)
+    if pkg:
+        print(f"Saved sources SPDX to {srcSpdxPath}")
+    else:
+        print(f"Couldn't generate sources SPDX file")
+
+    # create SPDX file for build
+    buildSpdxPath = os.path.join(spdxOutputDir, "build.spdx")
+    buildCfg = BuilderConfig()
+    buildCfg.documentName = "build"
+    buildCfg.documentNamespace = os.path.join(spdxNamespacePrefix, "build")
+    buildCfg.packageName = "build"
+    buildCfg.spdxID = "SPDXRef-build"
+    buildCfg.doSHA256 = True
+    buildCfg.scandir = cm.paths_build
+    pkg = makeSPDX(buildCfg, buildSpdxPath)
+    if pkg:
+        print(f"Saved build SPDX to {buildSpdxPath}")
+    else:
+        print(f"Couldn't generate build SPDX file")
+
 
 if __name__ == "__main__":
-    if len(sys.argv) < 2:
-        print(f"Usage: {sys.argv[0]} <path-to-cmake-api-index.json>")
+    if len(sys.argv) < 5:
+        print(f"Usage: {sys.argv[0]} <path-to-cmake-api-index.json> <path-to-top-level-sources> <spdx-output-dir> <spdx-namespace-prefix>")
         sys.exit(1)
 
     replyIndexPath = sys.argv[1]
-    cm = parseReply(replyIndexPath)
+    srcRootDir = sys.argv[2]
+    spdxOutputDir = sys.argv[3]
+    spdxNamespacePrefix = sys.argv[4]
+    makeCmakeSpdx(replyIndexPath, srcRootDir, spdxOutputDir, spdxNamespacePrefix)

--- a/main.py
+++ b/main.py
@@ -1,63 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import hashlib
-import os
 import sys
 
-from cmakefileapijson import parseReply
-from spdx.builder import BuilderConfig, makeSPDX
-
-def makeCmakeSpdx(replyIndexPath, srcRootDir, spdxOutputDir, spdxNamespacePrefix):
-    # get CMake info from build
-    replyIndexPath = sys.argv[1]
-    cm = parseReply(replyIndexPath)
-
-    # create SPDX file for sources
-    srcSpdxPath = os.path.join(spdxOutputDir, "sources.spdx")
-    srcCfg = BuilderConfig()
-    srcCfg.documentName = "sources"
-    srcCfg.documentNamespace = os.path.join(spdxNamespacePrefix, "sources")
-    srcCfg.packageName = "sources"
-    srcCfg.spdxID = "SPDXRef-sources"
-    srcCfg.doSHA256 = True
-    srcCfg.scandir = srcRootDir
-    srcCfg.excludeDirs.append(cm.paths_build)
-    srcPkg = makeSPDX(srcCfg, srcSpdxPath)
-    if srcPkg:
-        print(f"Saved sources SPDX to {srcSpdxPath}")
-    else:
-        print(f"Couldn't generate sources SPDX file")
-
-    # get hash of sources SPDX file, to use for build doc's extRef
-    hSHA256 = hashlib.sha256()
-    with open(srcSpdxPath, 'rb') as f:
-        buf = f.read()
-        hSHA256.update(buf)
-    srcSHA256 = hSHA256.hexdigest()
-
-    # create SPDX file for build
-    buildSpdxPath = os.path.join(spdxOutputDir, "build.spdx")
-    buildCfg = BuilderConfig()
-    buildCfg.documentName = "build"
-    buildCfg.documentNamespace = os.path.join(spdxNamespacePrefix, "build")
-    buildCfg.packageName = "build"
-    buildCfg.spdxID = "SPDXRef-build"
-    buildCfg.doSHA256 = True
-    buildCfg.scandir = cm.paths_build
-
-    # add external document ref to sources SPDX file
-    buildCfg.extRefs = [("DocumentRef-sources", srcCfg.documentNamespace, "SHA256", srcSHA256)]
-
-    # exclude CMake file-based API responses -- presume only used for this
-    # SPDX generation scan, not for actual build artifact
-    buildExcludeDir = os.path.join(cm.paths_build, ".cmake", "api")
-    buildCfg.excludeDirs.append(buildExcludeDir)
-
-    buildPkg = makeSPDX(buildCfg, buildSpdxPath)
-    if buildPkg:
-        print(f"Saved build SPDX to {buildSpdxPath}")
-    else:
-        print(f"Couldn't generate build SPDX file")
+from sbom import makeCmakeSpdx
 
 if __name__ == "__main__":
     if len(sys.argv) < 5:

--- a/sbom.py
+++ b/sbom.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import hashlib
+import os
+
+from cmakefileapijson import parseReply
+from spdx.builder import BuilderConfig, makeSPDX
+
+def makeCmakeSpdx(replyIndexPath, srcRootDir, spdxOutputDir, spdxNamespacePrefix):
+    # get CMake info from build
+    cm = parseReply(replyIndexPath)
+
+    # create SPDX file for sources
+    srcSpdxPath = os.path.join(spdxOutputDir, "sources.spdx")
+    srcCfg = BuilderConfig()
+    srcCfg.documentName = "sources"
+    srcCfg.documentNamespace = os.path.join(spdxNamespacePrefix, "sources")
+    srcCfg.packageName = "sources"
+    srcCfg.spdxID = "SPDXRef-sources"
+    srcCfg.doSHA256 = True
+    srcCfg.scandir = srcRootDir
+    srcCfg.excludeDirs.append(cm.paths_build)
+    srcPkg = makeSPDX(srcCfg, srcSpdxPath)
+    if srcPkg:
+        print(f"Saved sources SPDX to {srcSpdxPath}")
+    else:
+        print(f"Couldn't generate sources SPDX file")
+
+    # get hash of sources SPDX file, to use for build doc's extRef
+    hSHA256 = hashlib.sha256()
+    with open(srcSpdxPath, 'rb') as f:
+        buf = f.read()
+        hSHA256.update(buf)
+    srcSHA256 = hSHA256.hexdigest()
+
+    # create SPDX file for build
+    buildSpdxPath = os.path.join(spdxOutputDir, "build.spdx")
+    buildCfg = BuilderConfig()
+    buildCfg.documentName = "build"
+    buildCfg.documentNamespace = os.path.join(spdxNamespacePrefix, "build")
+    buildCfg.packageName = "build"
+    buildCfg.spdxID = "SPDXRef-build"
+    buildCfg.doSHA256 = True
+    buildCfg.scandir = cm.paths_build
+
+    # add external document ref to sources SPDX file
+    buildCfg.extRefs = [("DocumentRef-sources", srcCfg.documentNamespace, "SHA256", srcSHA256)]
+
+    # exclude CMake file-based API responses -- presume only used for this
+    # SPDX generation scan, not for actual build artifact
+    buildExcludeDir = os.path.join(cm.paths_build, ".cmake", "api")
+    buildCfg.excludeDirs.append(buildExcludeDir)
+
+    buildPkg = makeSPDX(buildCfg, buildSpdxPath)
+    if buildPkg:
+        print(f"Saved build SPDX to {buildSpdxPath}")
+    else:
+        print(f"Couldn't generate build SPDX file")

--- a/spdx/builder.py
+++ b/spdx/builder.py
@@ -215,6 +215,24 @@ def getHashes(filePath):
 
     return (hSHA1.hexdigest(), hSHA256.hexdigest(), hMD5.hexdigest())
 
+def calculateVerificationCode(bfs):
+    """
+    Calculate the SPDX Package Verification Code for all files in the package.
+
+    Arguments:
+        - bfs: array of BuilderFiles
+    Returns: verification code as string
+    """
+    hashes = []
+    for bf in bfs:
+        hashes.append(bf.sha1)
+    hashes.sort()
+    filelist = "".join(hashes)
+
+    hSHA1 = hashlib.sha1()
+    hSHA1.update(filelist.encode('utf-8'))
+    return hSHA1.hexdigest()
+
 def makeFileData(filePath, cfg, fileno):
     """
     Scan for expression, get hashes, and fill in data.
@@ -324,6 +342,7 @@ def makePackageData(cfg):
         pkg.licenseConcluded = normalizeExpression(licsConcluded)
     pkg.licenseInfoFromFiles = licsFromFiles
     pkg.files = bfs
+    pkg.verificationCode = calculateVerificationCode(bfs)
 
     return pkg
 

--- a/spdx/builder.py
+++ b/spdx/builder.py
@@ -369,7 +369,7 @@ Relationship: SPDXRef-DOCUMENT DESCRIBES {pkg.spdxID}
 
             # write file sections
             for bf in pkg.files:
-                f.write(f"""FileName: {bf.name}
+                f.write(f"""FileName: ./{os.path.relpath(bf.name, cfg.scandir)}
 SPDXID: {bf.spdxID}
 FileChecksum: SHA1: {bf.sha1}
 """)
@@ -399,7 +399,10 @@ def makeSPDX(cfg, spdxPath):
     Arguments:
         - cfg: BuilderConfig
         - spdxPath: path to write SPDX content
-    Returns: True on success, False on error.
+    Returns: BuilderPackage on success, None on failure.
     """
     pkg = makePackageData(cfg)
-    return outputSPDX(pkg, cfg, spdxPath)
+    if outputSPDX(pkg, cfg, spdxPath):
+        return pkg
+    else:
+        return None

--- a/spdx/builder.py
+++ b/spdx/builder.py
@@ -305,7 +305,7 @@ def makeFileData(filePath, cfg, timesSeen):
     Returns: BuilderFile
     """
     bf = BuilderFile()
-    bf.name = filePath
+    bf.name = os.path.join(".", os.path.relpath(filePath, cfg.scandir))
 
     filenameOnly = os.path.basename(filePath)
     bf.spdxID = getUniqueID(filenameOnly, timesSeen)
@@ -455,7 +455,7 @@ Relationship: SPDXRef-DOCUMENT DESCRIBES {pkg.spdxID}
 
             # write file sections
             for bf in pkg.files:
-                f.write(f"""FileName: ./{os.path.relpath(bf.name, cfg.scandir)}
+                f.write(f"""FileName: {bf.name}
 SPDXID: {bf.spdxID}
 FileChecksum: SHA1: {bf.sha1}
 """)
@@ -475,7 +475,7 @@ FileChecksum: SHA1: {bf.sha1}
             return True
 
     except OSError as e:
-        print(f"Unable to write to {spdxPath}: {str(e)}")
+        print(f"Error: Unable to write to {spdxPath}: {str(e)}")
         return False
 
 def makeSPDX(cfg, spdxPath):

--- a/spdx/builder.py
+++ b/spdx/builder.py
@@ -1,0 +1,405 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from datetime import datetime
+import hashlib
+import os
+import re
+
+class BuilderConfig:
+    def __init__(self):
+        super(BuilderConfig, self).__init__()
+
+        #####
+        ##### Document info
+        #####
+
+        # name of document
+        self.documentName = ""
+
+        # namespace for this document
+        self.documentNamespace = ""
+
+        #####
+        ##### Package / scan info
+        #####
+
+        # FIXME consider changing this to an array of multiple package configs
+        # FIXME so that one document can contain multiple packages
+
+        # name of package
+        self.packageName = ""
+
+        # SPDX ID for package, must begin with "SPDXRef-"
+        self.spdxID = ""
+
+        # download location for package, defaults to "NOASSERTION"
+        self.packageDownloadLocation = "NOASSERTION"
+
+        # should conclude package license based on detected licenses,
+        # AND'd together?
+        self.shouldConcludeLicense = True
+
+        # declared license, defaults to "NOASSERTION"
+        self.declaredLicense = "NOASSERTION"
+
+        # copyright text, defaults to "NOASSERTION"
+        self.copyrightText = "NOASSERTION"
+
+        # should include SHA256 hashes? (will also include SHA1 regardless)
+        self.doSHA256 = False
+
+        # should include MD5 hashes? (will also include MD5 regardless)
+        self.doMD5 = False
+
+        # root directory to be scanned
+        self.scandir = ""
+
+        # directories whose files should not be included
+        self.excludeDirs = [".git/"]
+
+        # directories whose files should be included, but not scanned
+        # FIXME not yet enabled
+        self.skipScanDirs = []
+
+        # number of lines to scan for SPDX-License-Identifier (0 = all)
+        # defaults to 20
+        self.numLinesScanned = 20
+
+class BuilderPackage:
+    def __init__(self):
+        super(BuilderPackage, self).__init__()
+
+        self.name = ""
+        self.spdxID = ""
+        self.downloadLocation = ""
+        # FIXME not yet calculated
+        self.verificationCode = ""
+        self.licenseConcluded = ""
+        self.licenseInfoFromFiles = []
+        self.licenseDeclared = ""
+        self.copyrightText = ""
+        self.files = []
+
+    def initFromConfig(self, cfg):
+        self.name = cfg.packageName
+        self.spdxID = cfg.spdxID
+        self.downloadLocation = cfg.packageDownloadLocation
+        self.verificationCode = ""
+        self.licenseConcluded = "NOASSERTION"
+        self.licenseInfoFromFiles = []
+        self.licenseDeclared = cfg.declaredLicense
+        self.copyrightText = cfg.copyrightText
+
+class BuilderFile:
+    def __init__(self):
+        super(BuilderFile, self).__init__()
+
+        self.name = ""
+        self.spdxID = ""
+        # FIXME not yet implementing FileType
+        self.type = ""
+        self.sha1 = ""
+        self.sha256 = ""
+        self.md5 = ""
+        self.licenseConcluded = "NOASSERTION"
+        self.licenseInfoInFile = []
+        self.copyrightText = "NOASSERTION"
+
+def shouldExcludeFile(filename, excludes):
+    """
+    Determines whether a file is in an excluded directory.
+
+    Arguments:
+        - filename: filename being tested
+        - excludes: array of excluded directory names
+    Returns: True if should exclude, False if not.
+    """
+    for exc in excludes:
+        if exc in filename:
+            return True
+    return False
+
+def getAllPaths(topDir, excludes):
+    """
+    Gathers a list of all paths for all files within topDir or its children.
+
+    Arguments:
+        - topDir: root directory of files being collected
+        - excludes: array of excluded directory names
+    Returns: array of paths
+    """
+    paths = []
+    # ignoring second item in tuple, which lists immediate subdirectories
+    for (currentDir, _, filenames) in os.walk(topDir):
+        for filename in filenames:
+            p = os.path.join(currentDir, filename)
+            if not shouldExcludeFile(p, excludes):
+                paths.append(p)
+    return sorted(paths)
+
+def parseLineForExpression(line):
+    """Return parsed SPDX expression if tag found in line, or None otherwise."""
+    p = line.partition("SPDX-License-Identifier:")
+    if p[2] == "":
+        return None
+    # strip away trailing comment marks and whitespace, if any
+    expression = p[2].strip()
+    expression = expression.rstrip("/*")
+    expression = expression.strip()
+    return expression
+
+def getExpressionData(filePath, numLines):
+    """
+    Scans the specified file for the first SPDX-License-Identifier:
+    tag in the file.
+
+    Arguments:
+        - filePath: path to file to scan.
+        - numLines: number of lines to scan for an expression before
+                    giving up. If 0, will scan the entire file.
+    Returns: parsed expression if found; None if not found.
+    """
+    with open(filePath, "r") as f:
+        try:
+            lineno = 0
+            for line in f:
+                lineno += 1
+                if numLines > 0 and lineno > numLines:
+                    break
+                expression = parseLineForExpression(line)
+                if expression is not None:
+                    return expression
+        except UnicodeDecodeError:
+            # invalid UTF-8 content
+            return None
+
+    # if we get here, we didn't find an expression
+    return None
+
+def splitExpression(expression):
+    """
+    Parse a license expression into its constituent identifiers.
+
+    Arguments:
+        - expression: SPDX license expression
+    Returns: array of split identifiers
+    """
+    # remove parens and plus sign
+    e2 = re.sub(r'\(|\)|\+', "", expression, flags=re.IGNORECASE)
+
+    # remove word operators, ignoring case, leaving a blank space
+    e3 = re.sub(r' AND | OR | WITH ', " ", e2, flags=re.IGNORECASE)
+
+    # and split on space
+    e4 = e3.split(" ")
+
+    return sorted(e4)
+
+def getHashes(filePath):
+    """
+    Scan for and return hashes.
+
+    Arguments:
+        - filePath: path to file to scan.
+    Returns: tuple of (SHA1, SHA256, MD5) hashes for filePath.
+    """
+    hSHA1 = hashlib.sha1()
+    hSHA256 = hashlib.sha256()
+    hMD5 = hashlib.md5()
+
+    with open(filePath, 'rb') as f:
+        buf = f.read()
+        hSHA1.update(buf)
+        hSHA256.update(buf)
+        hMD5.update(buf)
+
+    return (hSHA1.hexdigest(), hSHA256.hexdigest(), hMD5.hexdigest())
+
+def makeFileData(filePath, cfg, fileno):
+    """
+    Scan for expression, get hashes, and fill in data.
+
+    Arguments:
+        - filePath: path to file to scan.
+        - cfg: BuilderConfig for this scan.
+        - fileno: unique filenumber (used for SPDX ID)
+    Returns: BuilderFile
+    """
+    bf = BuilderFile()
+    bf.name = filePath
+    bf.spdxID = f"SPDXRef-File{fileno}"
+
+    (sha1, sha256, md5) = getHashes(filePath)
+    bf.sha1 = sha1
+    if cfg.doSHA256:
+        bf.sha256 = sha256
+    if cfg.doMD5:
+        bf.md5 = md5
+
+    expression = getExpressionData(filePath, cfg.numLinesScanned)
+    if expression != None:
+        bf.licenseConcluded = expression
+        bf.licenseInfoInFile = splitExpression(expression)
+
+    return bf
+
+def makeAllFileData(filePaths, cfg):
+    """
+    Scan all files for expressions and hashes, and fill in data.
+
+    Arguments:
+        - filePaths: sorted array of paths to files to scan.
+        - cfg: BuilderConfig for this scan.
+    Returns: array of BuilderFiles
+    """
+    bfs = []
+    fileno = 1
+    for filePath in filePaths:
+        bf = makeFileData(filePath, cfg, fileno)
+        fileno += 1
+        bfs.append(bf)
+
+    return bfs
+
+def getPackageLicenses(bfs):
+    """
+    Extract lists of all concluded and infoInFile licenses seen.
+
+    Arguments:
+        - bfs: array of BuilderFiles
+    Returns: tuple(sorted list of concluded license exprs,
+                   sorted list of infoInFile ID's)
+    """
+    licsConcluded = set()
+    licsFromFiles = set()
+    for bf in bfs:
+        licsConcluded.add(bf.licenseConcluded)
+        for licInfo in bf.licenseInfoInFile:
+            licsFromFiles.add(licInfo)
+    return (sorted(list(licsConcluded)), sorted(list(licsFromFiles)))
+
+def normalizeExpression(licsConcluded):
+    """
+    Combine array of license expressions into one AND'd expression,
+    adding parens where needed.
+
+    Arguments:
+        - licsConcluded: array of license expressions
+    Returns: string with single AND'd expression.
+    """
+    # return appropriate for simple cases
+    if len(licsConcluded) == 0:
+        return "NOASSERTION"
+    if len(licsConcluded) == 1:
+        return licsConcluded[0]
+
+    # more than one, so we'll need to combine them
+    # iff an expression has spaces, it needs parens
+    revised = []
+    for lic in licsConcluded:
+        if lic == "NONE" or lic == "NOASSERTION":
+            continue
+        if " " in lic:
+            revised.append(f"({lic})")
+        else:
+            revised.append(lic)
+    return " AND ".join(revised)
+
+def makePackageData(cfg):
+    """
+    Create package and call sub-functions to scan and create file data.
+
+    Arguments:
+        - cfg: BuilderConfig for this scan.
+    Returns: BuilderPackage
+    """
+    pkg = BuilderPackage()
+    pkg.initFromConfig(cfg)
+
+    filePaths = getAllPaths(cfg.scandir, cfg.excludeDirs)
+    bfs = makeAllFileData(filePaths, cfg)
+    (licsConcluded, licsFromFiles) = getPackageLicenses(bfs)
+
+    if cfg.shouldConcludeLicense:
+        pkg.licenseConcluded = normalizeExpression(licsConcluded)
+    pkg.licenseInfoFromFiles = licsFromFiles
+    pkg.files = bfs
+
+    return pkg
+
+def outputSPDX(pkg, cfg, spdxPath):
+    """
+    Write SPDX doc, package and files content to disk.
+
+    Arguments:
+        - pkg: BuilderPackage from makePackageData
+        - cfg: BuilderConfig
+        - spdxPath: path to write SPDX content
+    Returns: True on success, False on error.
+    """
+    try:
+        with open(spdxPath, 'w') as f:
+            # write document creation info section
+            f.write(f"""SPDXVersion: SPDX-2.2
+DataLicense: CC0-1.0
+SPDXID: SPDXRef-DOCUMENT
+DocumentName: {cfg.documentName}
+DocumentNamespace: {cfg.documentNamespace}
+Creator: Tool: cmake-spdx
+Created: {datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")}
+
+""")
+
+            # write package section
+            f.write(f"""PackageName: {pkg.name}
+SPDXID: {pkg.spdxID}
+PackageDownloadLocation: {pkg.downloadLocation}
+FilesAnalyzed: true
+PackageVerificationCode: {pkg.verificationCode}
+PackageLicenseConcluded: {pkg.licenseConcluded}
+""")
+            for licFromFiles in pkg.licenseInfoFromFiles:
+                f.write(f"PackageLicenseInfoFromFiles: {licFromFiles}\n")
+            f.write(f"""PackageLicenseDeclared: {pkg.licenseDeclared}
+PackageCopyrightText: NOASSERTION
+
+Relationship: SPDXRef-DOCUMENT DESCRIBES {pkg.spdxID}
+
+""")
+
+            # write file sections
+            for bf in pkg.files:
+                f.write(f"""FileName: {bf.name}
+SPDXID: {bf.spdxID}
+FileChecksum: SHA1: {bf.sha1}
+""")
+                if bf.sha256 != "":
+                    f.write(f"FileChecksum: SHA256: {bf.sha256}\n")
+                if bf.md5 != "":
+                    f.write(f"FileChecksum: MD5: {bf.md5}\n")
+                f.write(f"LicenseConcluded: {bf.licenseConcluded}\n")
+                if len(bf.licenseInfoInFile) == 0:
+                    f.write(f"LicenseInfoInFile: NONE\n")
+                else:
+                    for licInfoInFile in bf.licenseInfoInFile:
+                        f.write(f"LicenseInfoInFile: {licInfoInFile}\n")
+                f.write(f"FileCopyrightText: {bf.copyrightText}\n\n")
+
+            # we're done for now; will do other relationships later
+            return True
+
+    except OSError as e:
+        print(f"Unable to write to {spdxPath}: {str(e)}")
+        return False
+
+def makeSPDX(cfg, spdxPath):
+    """
+    Scan, create and write SPDX details to disk.
+
+    Arguments:
+        - cfg: BuilderConfig
+        - spdxPath: path to write SPDX content
+    Returns: True on success, False on error.
+    """
+    pkg = makePackageData(cfg)
+    return outputSPDX(pkg, cfg, spdxPath)

--- a/spdx/builder.py
+++ b/spdx/builder.py
@@ -19,6 +19,11 @@ class BuilderConfig:
         # namespace for this document
         self.documentNamespace = ""
 
+        # external document refs that this document uses
+        # list of tuples of external doc refs, in format:
+        #    [("DocumentRef-<docID>", "<namespaceURI>", "<hashAlg>", "<hashValue>"), ...]
+        self.extRefs = []
+
         #####
         ##### Package / scan info
         #####
@@ -367,6 +372,10 @@ Creator: Tool: cmake-spdx
 Created: {datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")}
 
 """)
+            # write any external document references
+            for extRef in cfg.extRefs:
+                f.write(f"ExternalDocumentRef: {extRef[0]} {extRef[1]} {extRef[2]}:{extRef[3]}\n")
+            f.write(f"\n")
 
             # write package section
             f.write(f"""PackageName: {pkg.name}

--- a/spdx/builder.py
+++ b/spdx/builder.py
@@ -364,7 +364,7 @@ SPDXID: SPDXRef-DOCUMENT
 DocumentName: {cfg.documentName}
 DocumentNamespace: {cfg.documentNamespace}
 Creator: Tool: cmake-spdx
-Created: {datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")}
+Created: {datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")}
 
 """)
 

--- a/spdx/builder.py
+++ b/spdx/builder.py
@@ -370,7 +370,6 @@ DocumentName: {cfg.documentName}
 DocumentNamespace: {cfg.documentNamespace}
 Creator: Tool: cmake-spdx
 Created: {datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")}
-
 """)
             # write any external document references
             for extRef in cfg.extRefs:

--- a/spdx/builder.py
+++ b/spdx/builder.py
@@ -72,7 +72,6 @@ class BuilderPackage:
         self.name = ""
         self.spdxID = ""
         self.downloadLocation = ""
-        # FIXME not yet calculated
         self.verificationCode = ""
         self.licenseConcluded = ""
         self.licenseInfoFromFiles = []

--- a/spdx/relationships.py
+++ b/spdx/relationships.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+def resolveRelationshipID(srcRootDir, srcPkg, buildPkg, filepath):
+    """
+    Determines the corresponding SPDX ID for filepath, depending on whether
+    it is a source file or build file.
+
+    Arguments:
+        - srcRootDir: root directory of sources being scanned
+        - srcPkg: source SPDX Package section data
+        - buildPkg: build SPDX Package section data
+        - filepath: path to file being resolved; might be absolute or relative
+
+    Returns: tuple (is_build, identifier) where:
+             is_build is True if filepath is for a build file, False if source file
+             identifier is the resolved ID or None if not resolvable
+    """
+    # figure out relative path we're searching for
+    # FIXME this is probably not the right way to do this
+    is_build = filepath.startswith("./") or filepath.startswith(".\\")
+
+    if is_build:
+        pkg = buildPkg
+        searchPath = filepath
+    else:
+        pkg = srcPkg
+        # make sure filepath is actually within the sources root dir
+        checkPath = os.path.relpath(filepath, srcRootDir)
+        # FIXME this is also probably not the right way to do this
+        if checkPath.startswith("../") or checkPath.startswith("..\\"):
+            # points to somewhere outside our sources root dir;
+            # we won't be able to create this relationship
+            print(f"{filepath} is not in sources root dir {srcRootDir}, can't create relationship")
+            return (is_build, None)
+        searchPath = os.path.join(".", checkPath)
+
+    # search through files for the one with this filename
+    for f in pkg.files:
+        if f.name == searchPath:
+            return (is_build, f.spdxID)
+
+    print(f"{filepath} not found in package, can't create relationship")
+    return (is_build, None)
+
+def outputSPDXRelationships(srcRootDir, srcPkg, buildPkg, rlns, spdxPath):
+    """
+    Create and append SPDX relationships to the end of the previously-created
+    SPDX build document.
+
+    Arguments:
+        - srcRootDir: root directory of sources being scanned
+        - srcPkg: source SPDX Package section data
+        - buildPkg: build SPDX Package section data
+        - rlns: Cmake relationship data from call to getCmakeRelationships()
+        - spdxPath: path to previously-started SPDX build document
+    Returns: True on success, False on error.
+    """
+    try:
+        with open(spdxPath, "a") as f:
+            for rln in rlns:
+                (is_buildA, rlnIDA) = resolveRelationshipID(srcRootDir, srcPkg, buildPkg, rln[0])
+                (is_buildB, rlnIDB) = resolveRelationshipID(srcRootDir, srcPkg, buildPkg, rln[2])
+                if not rlnIDA or not rlnIDB:
+                    continue
+
+                # add DocumentRef- prefix for sources files
+                if not is_buildA:
+                    rlnIDA = "DocumentRef-sources:" + rlnIDA
+                if not is_buildB:
+                    rlnIDB = "DocumentRef-sources:" + rlnIDB
+
+                f.write(f"Relationship: {rlnIDA} {rln[1]} {rlnIDB}\n")
+            return True
+
+    except OSError as e:
+        print(f"Error: Unable to append to {spdxPath}: {str(e)}")
+        return False


### PR DESCRIPTION
This PR adds support for automatically creating an SPDX file for the CMake build.

* [x] scan files for hashes
* [x] scan files for short-form SPDX ID's (e.g. `SPDX-License-Identifier: Apache-2.0`)
* [x] exclude particular directories
* [x] write out as SPDX document
* [x] calculate package-wide license
* [x] calculate package verification code
* [x] fix document Created time to use UTC, not local time
* [x] strip out common prefix directory from file paths
* [x] run first for sources and second for build directory
* [x] enable passing ExternalDocumentRef(s) into BuilderConfig
  - so that we can pass in the source SPDX file's namespace as a ref to the build SPDX file
  - note that we'll also want to pass in the source SPDX file's hash, after any necessary adjustments are made to the doc
* [x] create relationships from build artifacts back to sources

Optional improvements (may move to separate PRs):

* [x] use more intelligible identifiers rather than "File#"
* determine (or guess) file type => moved to #2 
* after relationships between sources and binaries are set up, use detected license(s) in sources to conclude license(s) for corresponding binaries => moved to #3
* instead of creating a single "sources" package with the full contents of everything provided, should we create: => moved to #4
  - separate package (sources? sources and build?) for each project in codemodel.configurations.projects
  - and, if so, would it only include the directories in directoryIndexes? and/or childIndexes?


Signed-off-by: Steve Winslow <steve@swinslow.net>