### PR TITLE
Add argparse to main.py, add Config class to override default settings, update to SPDX 2.3

### DIFF
--- a/cmakefileapijson.py
+++ b/cmakefileapijson.py
@@ -225,7 +225,7 @@ def parseTargetArchive(target, js):
     if archive_dict == {}:
         return
     target.archive_lto = archive_dict.get("lto", False)
- 
+
     fragments_arr = archive_dict.get("commandFragments", [])
     for fragment_dict in fragments_arr:
         fragment = cmakefileapi.TargetCommandFragment()

--- a/docs/process.md
+++ b/docs/process.md
@@ -42,13 +42,19 @@ Now that the build is complete and we have the metadata from the CMake API JSON 
 cmake-spdx takes the following arguments:
 
 ```
-python3 main.py <path-to-cmake-api-index.json> <path-to-top-level-sources> <spdx-output-dir> <spdx-namespace-prefix>
+python3 main.py \
+  --build-dir <path-to-cmake-build-dir> \
+  --output-dir <spdx-output-dir> \
+  --ns <spdx-namespace-prefix>
 ```
 
 For the proof-of-concept run, I called it with:
 
 ```
-> python3 main.py api-example-reply/api/v1/reply/index-2020-08-29T18-34-19-0138.json /home/steve/programming/zephyr/zephyrproject/ ./scratch/ https://swinslow.net/zephyr/
+> python3 main.py \
+  --build-dir api-example-reply \
+  --output-dir ./scratch/ \
+  --ns 'https://swinslow.net/zephyr/'
 ```
 
 The arguments are:

--- a/main.py
+++ b/main.py
@@ -1,15 +1,47 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import sys
+import argparse
+import glob
+import os
 
-from sbom import makeSpdxFromCmakeReply
+import sbom
+
+excludeDirs = [".git/"]
+
+def makeSpdxFromCmakeReply(buildDir: str, outputDir: str, ns: str, documentNamePrefix: str):
+    indexSearchPath = os.path.join(buildDir, '.cmake/api/v1/reply', 'index-*.json')
+    indexFiles = glob.glob(indexSearchPath)
+
+    if len(indexFiles) == 0:
+        print(f"Couldn't find index JSON file in {indexSearchPath}")
+        exit(1)
+
+    config = sbom.Config(
+        replyIndexPath=indexFiles[0],
+        spdxOutputDir=outputDir,
+        spdxNamespacePrefix=ns,
+        excludeDirs=excludeDirs,
+        documentNamePrefix=documentNamePrefix,
+    )
+
+    sbom.makeSpdxFromCmakeReply(config)
 
 if __name__ == "__main__":
-    if len(sys.argv) < 4:
-        print(f"Usage: {sys.argv[0]} <path-to-cmake-api-index.json> <spdx-output-dir> <spdx-namespace-prefix>")
-        sys.exit(1)
+    parser = argparse.ArgumentParser(
+        prog='cmake-spdx',
+        description="Generate SPDX from CMake File API index",
+    )
 
-    replyIndexPath = sys.argv[1]
-    spdxOutputDir = sys.argv[2]
-    spdxNamespacePrefix = sys.argv[3]
-    makeSpdxFromCmakeReply(replyIndexPath, spdxOutputDir, spdxNamespacePrefix)
+    parser.add_argument('-b', '--build-dir', help='Path to CMake build directory', required=True)
+    parser.add_argument('-o', '--output-dir', help='Output directory for SPDX files', required=True)
+    parser.add_argument('-n', '--ns', help='Namespace prefix for SPDX files', required=True)
+    parser.add_argument('--doc-name-prefix', help='Document name prefix', default='')
+
+    args = parser.parse_args()
+
+    makeSpdxFromCmakeReply(
+        buildDir=args.build_dir,
+        outputDir=args.output_dir,
+        ns=args.ns,
+        documentNamePrefix=args.doc_name_prefix,
+    )

--- a/spdx/builder.py
+++ b/spdx/builder.py
@@ -28,7 +28,8 @@ class BuilderDocumentConfig:
         self.packageConfigs = {}
 
 class BuilderPackageConfig:
-    def __init__(self):
+
+    def __init__(self, excludeDirs: list[str]):
         super(BuilderPackageConfig, self).__init__()
 
         #####
@@ -64,7 +65,7 @@ class BuilderPackageConfig:
         self.scandir = ""
 
         # directories whose files should not be included
-        self.excludeDirs = [".git/"]
+        self.excludeDirs = excludeDirs
 
         # directories whose files should be included, but not scanned
         # FIXME not yet enabled
@@ -443,12 +444,12 @@ def outputSPDX(doc, spdxPath):
     try:
         with open(spdxPath, 'w') as f:
             # write document creation info section
-            f.write(f"""SPDXVersion: SPDX-2.2
+            f.write(f"""SPDXVersion: SPDX-2.3
 DataLicense: CC0-1.0
 SPDXID: SPDXRef-DOCUMENT
 DocumentName: {doc.config.documentName}
 DocumentNamespace: {doc.config.documentNamespace}
-Creator: Tool: cmake-spdx
+Creator: Tool: cmake-spdx-0.0.1
 Created: {datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")}
 """)
             # write any external document references


### PR DESCRIPTION
Hi @swinslow,

Thank you for putting this tool out there, and the other work you've done for SPDX!

I've found `cmake-spdx` valuable for auto-generating SBOMs for smaller CMake projects. The closest other tool I've found to meeting my needs is [syft](https://github.com/anchore/syft) but it requires using `conan` as a package manager which is kind of overkill for a lot of projects I'm working on which rely on `git submodule` for dependencies, the `cmake-file-api` seems like a good/scalable approach.

Also wanted to gauge what your appetite is for keeping this project going as it seems like you used what you did here as a basis for the `west spdx` command a few years ago: https://github.com/zephyrproject-rtos/zephyr/blob/main/scripts/west_commands/spdx.py

I still think this project has value for older CMake codebases that don't have the ability to switch to zephyr and would like to help continue to improve it if other people still find it valuable, merging back changes here to avoid having to maintain a fork (unless that's what you prefer).

In this PR I've made a couple of changes that I've found valuable myself, happy to break up into smaller/separate PRs if needed:
1. Use `argparse` for `main.py` so user doesn't need to remember positional arg locations (also fix some outdated user instructions)
2. Added a `Config` class to pass into the entry point to allow for future customization. Currently allows to customize `excludeDirs` and `documentNamePrefix`.
3. Updated SBOM output from SPDX 2.2 to SPDX 2.3, I haven't verified if it's truly conformant, but if I find other tools complaining later I'm happy to help fix to make it so.

Some more enhancements I'm planning on working on:
1. Update documentation to discuss https://cmake.org/cmake/help/latest/command/cmake_file_api.html which can be used instead of manually creating the API query file (added in CMake 3.27 so fairly new, Zephyr workflow might even be simplified if this is added.
2. Add more customization abilities, for example, automatically add CPEs/PURLs to third-party libraries/targets so that the SBOMs can be fed into other tools to look for vulnerabilities.
3. Continue to look at the `west spdx` command to see if there are other useful features added there that could be ported to this tool.

Thank You,
Josh